### PR TITLE
HCW-102: Moving secret definition into deploy module

### DIFF
--- a/infrastructure/deploy/app_deploy.tf
+++ b/infrastructure/deploy/app_deploy.tf
@@ -121,3 +121,6 @@ resource "aws_codebuild_project" "hcw-api-destroy-pr-env" {
   }
 }
 
+resource "aws_secretsmanager_secret" "apim_account_private_key" {
+  name = "apim-account-private-key"
+}

--- a/infrastructure/mgmt/deployment_pipeline.tf
+++ b/infrastructure/mgmt/deployment_pipeline.tf
@@ -203,7 +203,7 @@ resource "aws_codepipeline" "app_deployment_pipeline" {
           },
           {
             name  = "apim_private_key_secret_arn"
-            value = aws_secretsmanager_secret.apim_account_private_key.arn
+            value = data.aws_secretsmanager_secret.apim_account_private_key.arn
             type  = "PLAINTEXT"
           }
         ])
@@ -366,7 +366,7 @@ resource "aws_iam_policy" "integration_tests_policy" {
       {
         "Effect" : "Allow",
         "Action" : "secretsmanager:GetSecretValue"
-        "Resource" : aws_secretsmanager_secret.apim_account_private_key.arn
+        "Resource" : data.aws_secretsmanager_secret.apim_account_private_key.arn
       }
     ]
   })

--- a/infrastructure/mgmt/secrets.tf
+++ b/infrastructure/mgmt/secrets.tf
@@ -1,3 +1,3 @@
-resource "aws_secretsmanager_secret" "apim_account_private_key" {
+data "aws_secretsmanager_secret" "apim_account_private_key" {
   name = "apim-account-private-key"
 }


### PR DESCRIPTION
The deploy module is designed to run once in every AWS environment (as opposed to mgmt which runs only once across all accounts). This secret needs to be in all AWS accounts, so it should be in the deploy module