### PR TITLE
added example values and descriptions for the schema

### DIFF
--- a/specification/healthcare-worker-api.yaml
+++ b/specification/healthcare-worker-api.yaml
@@ -173,7 +173,7 @@ paths:
           name: identifier
           description: SDS user ID which uniquely identifies a person.
           required: true
-          example: 123456789012
+          example: "123456789012"
           schema:
             type: string
           explode: true
@@ -232,7 +232,7 @@ paths:
           name: practitioner.identifier
           description: SDS user ID which uniquely identifies a person.
           required: true
-          example: 123456789012
+          example: "123456789012"
           schema:
             type: string
           explode: true
@@ -272,11 +272,12 @@ components:
       properties:
         resourceType:
           type: string
-          default: Practitioner
+          default: "Practitioner"
+          example: "Practitioner"
         id:
           type: string
           description: Auto generated unique ID for the person.
-          example: 123456789012
+          example: "123456789012"
         identifier:
           type: array
           description: Auto generated unique ID for the person.
@@ -288,7 +289,7 @@ components:
                 default: https://fhir.nhs.uk/Id/sds-user-id
               value:
                 type: string
-                example: 123456789012
+                example: "123456789012"
         active:
           type: boolean
           description: Describes the active status of the Practitioner record in the directory.
@@ -302,43 +303,44 @@ components:
               use:
                 type: string
                 description: Identifies the purpose for this name.
-                default: usual
+                default: "usual"
+                example: "usual"
               family:
                 type: string
                 description: That part of a person's name which is used to describe family, clan, tribal group, or marital association.
-                example: Smith
+                example: "Smith"
               given:
                 type: string
                 description: The forenames or given names of a person. Includes middle names.
-                example: Jane Alison
+                example: "Jane Alison"
               prefix:
                 type: string
                 description: Standard form of address used to precede a person's name
-                example: Ms
+                example: "Ms"
     PractitionerRole:
       type: object
       properties:
         resourceType:
           type: string
-          default: PractitionerRole
+          default: "PractitionerRole"
+          example: "PractitionerRole"
         id:
           type: string
-          description: Id of the practitioner role
+          description: Auto generated unique ID for the role.
+          example: "123456789012"
         identifier:
           type: array
-          description: Auto generated unique ID for the role.
+          description: An array of identifiers which uniquely refer to this practioner role profile.
           items:
             type: object
             properties:
-              system:
-                type: string
-                default: https://fhir.nhs.uk/Id/sds-role-profile-id
               value:
                 type: string
-                example: 123456789012
+                description: Auto generated unique ID for the role.
+                example: "123456789012"
         active:
           type: boolean
-          description: Describes the active status of the Practitioner record in the directory.
+          description: Describes the active status of the role record in the directory. A status of True indicates the record is active.
           example: True
         practitioner:
           $ref: '#/components/schemas/Reference'
@@ -357,29 +359,45 @@ components:
             $ref: '#/components/schemas/CodeableConcept'
     Reference:
       type: object
+      description: A reference from one resource to another.
       properties:
         resourceType:
           type: string
-          default: Identifier
+          description: Indicates the type of resource being referred to.
+          default: "Identifier"
         system:
           type: string
+          description: Indicates the coded system which the value sits within. For example, if the value shows an ODS code, this field shows a URL describing ODS code as a system.
+          example: "https://www.datadictionary.nhs.uk/attributes/organisation_code.html"
         value:
           type: string
+          description: Indicates the coded reference to a unique object which is being referred to.
+          example: "RHQ"
     CodeableConcept:
       type: object
       properties:
         resourceType:
           type: string
-          default: CodeableConcept
+          description: A reference to a code defined by a terminology system.
+          default: "CodeableConcept"
+          example: "CodeableConcept"
         coding:
           type: object
           properties:
             resourceType:
               type: string
-              default: Coding
+              description: A reference to a code defined by a terminology system.
+              default: "Coding"
+              example: "Coding"
             system:
               type: string
+              description: Indicates the terminology system which the value sits within. For example, if the value shows a role code, this field shows a URL describing role codes as a system.
+              example: "https://digital.nhs.uk/data-and-information/publications/statistical/appointments-in-general-practice/sds-role-groups"
             code:
               type: string
+              description: The code from within the terminology system.
+              example: "R0110"
             display:
               type: string
+              description: The display value from within the terminology system, if different from the code.
+              example: "Specialist Registrar"


### PR DESCRIPTION
Made descriptive changes to the spec (adding example values and field descriptions).
added double quotes to string fields for correct formatting.
removed the "system" property for PractitionerRole since there is no public spec for SDS role profile ID which can be linked to (edit: the closest would be the EIS spec but that's a 50+ page word document)